### PR TITLE
Reduce global access to `composition` in favor of references

### DIFF
--- a/src/tunecomposer/Command.java
+++ b/src/tunecomposer/Command.java
@@ -11,13 +11,12 @@ package tunecomposer;
  * TODO this
  */
 public interface Command {
-    
     /**
-     * Does the command
+     * Does the command.
      */
     public void execute();
     /**
-     * undoes the command
+     * Undoes the command.
      */
     public void unexecute();
 }

--- a/src/tunecomposer/CommandHistory.java
+++ b/src/tunecomposer/CommandHistory.java
@@ -14,8 +14,10 @@ import java.util.Stack;
 public class CommandHistory {
     private final Stack<Command> undoableCommands;
     private final Stack<Command> undoneCommands;
+    private final Composition composition;
     
-    public CommandHistory(){
+    public CommandHistory(Composition composition) {
+        this.composition = composition;
         undoableCommands = new Stack<>();
         undoneCommands = new Stack<>();
     }
@@ -36,7 +38,7 @@ public class CommandHistory {
         Command undoing = undoableCommands.pop();
         undoing.unexecute();
         undoneCommands.push(undoing);
-        TuneComposer.composition.clearSelectionTracker();
+        composition.clearSelectionTracker();
     }
     
     /**
@@ -47,7 +49,7 @@ public class CommandHistory {
         Command redoing = undoneCommands.pop();
         redoing.execute();
         undoableCommands.push(redoing);
-        TuneComposer.composition.clearSelectionTracker();
+        composition.clearSelectionTracker();
     }
     
     /**

--- a/src/tunecomposer/Composition.java
+++ b/src/tunecomposer/Composition.java
@@ -74,7 +74,7 @@ public class Composition {
      */
     public void deleteSelection() {
         HashSet<TuneRectangle> forCommand = new HashSet<>(selectedRoots);
-        TuneComposer.history.addNewCommand(new DeletionCommand(forCommand));
+        TuneComposer.history.addNewCommand(new DeletionCommand(this, forCommand));
         for(TuneRectangle rect : selectedRoots) {
             remove(rect);
             rect.delete(pane);
@@ -93,7 +93,7 @@ public class Composition {
         Gesture newGesture = new Gesture(group);
         HashSet<Gesture> forCommand = new HashSet<>();
         forCommand.add(newGesture);
-        TuneComposer.history.addNewCommand(new GroupCommand(forCommand, true));
+        TuneComposer.history.addNewCommand(new GroupCommand(this, forCommand, true));
         
     }
 
@@ -115,7 +115,7 @@ public class Composition {
                 forCommand.add(children);
             }
         }
-        TuneComposer.history.addNewCommand(new GroupCommand(forCommand, false));
+        TuneComposer.history.addNewCommand(new GroupCommand(this, forCommand, false));
     }
     
     /**

--- a/src/tunecomposer/Composition.java
+++ b/src/tunecomposer/Composition.java
@@ -119,8 +119,9 @@ public class Composition {
     }
     
     /**
-     * Creates a group with the given tunerectangles as children
-     * @param toGroup, the tunerectangles to be children
+     * Creates a group with the given tunerectangles as children.
+     * TODO Refactor GroupCommand and deprecate this
+     * @param toGroup the tunerectangles to be children
      * @return the new gesture
      */
     public Gesture groupTuneRectangles(HashSet<TuneRectangle> toGroup) {
@@ -132,8 +133,9 @@ public class Composition {
     }
 
     /**
-     * Ungroups a given gestures
-     * @param Ungroup, the gesture to ungroup
+     * Ungroups the given gesture.
+     * TODO Refactor GroupCommand and deprecate this
+     * @param Ungroup the gesture to ungroup
      * @return the old children of the given gesture
      */
     public HashSet<TuneRectangle> ungroupGesture(Gesture Ungroup) {
@@ -148,40 +150,15 @@ public class Composition {
     }
 
     /**
-     * Adds a tunerectangle to the composition
-     * @param rect , the tunerectangle to add
+     * Adds a tunerectangle to the composition.
+     * @param rect the tunerectangle to add
      */
     public void add(TuneRectangle rect) {
-        if(pane.getChildren().contains(rect)){
-            return;
+        allRoots.add(rect);
+
+        if (!pane.getChildren().contains(rect)) {
+            pane.getChildren().add(rect);
         }
-        else if(rect instanceof NoteBar){
-            add((NoteBar) rect);
-        }
-        else{
-            add((Gesture) rect);
-        }
-    }
-    /**
-     * Adds a notebar to the composition.
-     * Should be called on a newly created or un-deleted note.
-     * @param rect the notebar to be added
-     */
-    public void add(NoteBar rect) {
-        pane.getChildren().add(rect);
-        rect.note.addToAllNotes();
-        if(rect.getParentGesture() == null) allRoots.add(rect);
-    }
-    
-    /**
-     * Adds a gesture to the composition.
-     * Should be called on a newly created or un-deleted note.
-     * @param rect the gesture to be added
-     */
-    public void add(Gesture rect) {
-        pane.getChildren().add(rect);
-        rect.addChildrenToComposition();
-        if(rect.getParentGesture() == null) allRoots.add(rect);
     }
 
     /**
@@ -198,7 +175,8 @@ public class Composition {
     }
     
     /**
-     * notifies the tracker that this tunerectangle has changed selection state
+     * Notifies the tracker that this tunerectangle has changed selection
+     * state.
      * @param rect, the tunerectangle that changed
      */
     public void trackRectSelect(TuneRectangle rect){
@@ -236,7 +214,7 @@ public class Composition {
      * Expands the bounds of selection to include a new tunerectangle
      * @param root, the new tunerectangle
      */
-    private void updateBoundsNewRect(TuneRectangle root){
+    private void updateBoundsNewRect(TuneRectangle root) {
         if(selectionLeft == null || root.getX() < selectionLeft){selectionLeft = root.getX();}
         if(selectionTop == null || root.getY() < selectionTop){selectionTop = root.getY();}
         if(selectionRight == null || root.getX()+root.getWidth() > selectionRight){selectionRight = root.getX()+root.getWidth();}
@@ -267,18 +245,6 @@ public class Composition {
         }
     }
     
-    /**
-     * updates selection bounds after a move
-     * @param deltaX, the change in x
-     * @param deltaY, the change in y 
-     */
-    public void updateSelectionBounds(double deltaX, double deltaY){
-        selectionLeft += deltaX;
-        selectionRight += deltaX;
-        selectionTop += deltaY;
-        selectionBottom += deltaY;
-    }
-
     /**
      * Tells whether the given TuneRectangle is selected.
      * @param root the TuneRectangle in question

--- a/src/tunecomposer/CreationCommand.java
+++ b/src/tunecomposer/CreationCommand.java
@@ -11,19 +11,21 @@ package tunecomposer;
  */
 public class CreationCommand implements Command {
 
+    private final Composition composition;
     private final NoteBar newNote;
     private final SelectionCommand selection;
     
-    public CreationCommand(NoteBar created) {
+    public CreationCommand(Composition composition, NoteBar created) {
+        this.composition = composition;
         newNote = created;
-        selection = new SelectionCommand();
+        selection = new SelectionCommand(composition);
     }
     /**
      * creates the note
      */
     @Override
     public void execute() {
-        TuneComposer.composition.add(newNote);
+        composition.add(newNote);
         selection.execute();
     }
     /**
@@ -31,7 +33,7 @@ public class CreationCommand implements Command {
      */
     @Override
     public void unexecute() {
-        TuneComposer.composition.remove(newNote);
+        composition.remove(newNote);
         selection.unexecute();
     }
     

--- a/src/tunecomposer/DeletionCommand.java
+++ b/src/tunecomposer/DeletionCommand.java
@@ -12,31 +12,33 @@ import java.util.HashSet;
  * @author vankoesd
  */
 public class DeletionCommand implements Command {
+    private final Composition composition;
     private final HashSet<TuneRectangle> deletedRects;
     
-    public DeletionCommand(HashSet<TuneRectangle> rects) {
+    public DeletionCommand(Composition composition, HashSet<TuneRectangle> rects) {
+        this.composition = composition;
         deletedRects = rects;
-        new SelectionCommand();
+        new SelectionCommand(composition);
     }
     
     /**
-     * deletes the note
+     * Deletes the note.
      */
     @Override
     public void execute() {
         for(TuneRectangle rect : deletedRects){
-            TuneComposer.composition.remove(rect);
+            composition.remove(rect);
         }
     }
 
     /**
-     * undeletes the note
+     * Undeletes the note.
      */
     @Override
     public void unexecute() {
-        TuneComposer.composition.clearSelection();
+        composition.clearSelection();
         for (TuneRectangle rect : deletedRects){
-            TuneComposer.composition.add(rect);
+            composition.add(rect);
             rect.addToSelection();
         }
     }

--- a/src/tunecomposer/Gesture.java
+++ b/src/tunecomposer/Gesture.java
@@ -48,6 +48,7 @@ public class Gesture extends TuneRectangle {
 
     /**
      * Selects this gesture and everything contained by it.
+     * TODO Extract an `applySelectStyle` method and deprecate this.
      */
     @Override
     public void addToSelection() {

--- a/src/tunecomposer/GroupCommand.java
+++ b/src/tunecomposer/GroupCommand.java
@@ -11,15 +11,20 @@ import java.util.HashSet;
  *
  * @author vankoesd
  */
-public class GroupCommand implements Command{
+public class GroupCommand implements Command {
     
+    private final Composition composition;
     private HashSet<Gesture> toUngroup;
     private HashSet<HashSet<TuneRectangle>> toGroup;
 
-    public GroupCommand(HashSet stuff, boolean wasGrouped){
-        if(wasGrouped){groupedConstructor(stuff);}
-        else{ungroupedConstructor(stuff);}
-        new SelectionCommand();
+    public GroupCommand(Composition composition, HashSet stuff, boolean wasGrouped){
+        this.composition = composition;
+        if (wasGrouped) {
+            groupedConstructor(stuff);
+        } else {
+            ungroupedConstructor(stuff);
+        }
+        new SelectionCommand(composition);
     }
     /**
      *Sets up the command
@@ -61,9 +66,9 @@ public class GroupCommand implements Command{
     private void toggle(){
         if(toUngroup.isEmpty()){
             for(HashSet<TuneRectangle> rectGroup : toGroup){
-                Gesture toAdd = TuneComposer.composition.groupTuneRectangles(rectGroup);
-                if(!TuneComposer.composition.isSelectedTop(toAdd)){
-                    TuneComposer.composition.addToSelection(toAdd);
+                Gesture toAdd = composition.groupTuneRectangles(rectGroup);
+                if(!composition.isSelectedTop(toAdd)){
+                    composition.addToSelection(toAdd);
                 }
                 toUngroup.add(toAdd);
             }
@@ -71,7 +76,7 @@ public class GroupCommand implements Command{
         }
         else{
             for(Gesture gest : toUngroup){
-                toGroup.add(new HashSet<TuneRectangle>(TuneComposer.composition.ungroupGesture(gest)));
+                toGroup.add(new HashSet<TuneRectangle>(composition.ungroupGesture(gest)));
             }
             toUngroup.clear();
         }

--- a/src/tunecomposer/MoveCommand.java
+++ b/src/tunecomposer/MoveCommand.java
@@ -23,9 +23,9 @@ public class MoveCommand implements Command {
     private final double yChange;
     private final Command selection;
 
-    public MoveCommand(Composition composition, Set edits, double dX, double dY) {
+    public MoveCommand(Composition composition, double dX, double dY) {
         this.composition = composition;
-        editedRects = edits;
+        editedRects = composition.getSelectionTop();
         xChange = dX;
         yChange = dY;
         selection = new SelectionCommand(composition);

--- a/src/tunecomposer/MoveCommand.java
+++ b/src/tunecomposer/MoveCommand.java
@@ -17,16 +17,18 @@ import java.util.Set;
 //TODO fix that
 public class MoveCommand implements Command {
     
+    private final Composition composition;
     private final Set<TuneRectangle> editedRects;
     private final double xChange;
     private final double yChange;
     private final Command selection;
 
-    public MoveCommand(Set edits, double dX, double dY) {
+    public MoveCommand(Composition composition, Set edits, double dX, double dY) {
+        this.composition = composition;
         editedRects = edits;
         xChange = dX;
         yChange = dY;
-        selection = new SelectionCommand();
+        selection = new SelectionCommand(composition);
     }
     
     /**
@@ -34,10 +36,15 @@ public class MoveCommand implements Command {
      */
     @Override
     public void execute() {
-        for(TuneRectangle rect : editedRects){
-            if(rect instanceof Gesture){((Gesture)rect).setStart();}
+        for(TuneRectangle rect : editedRects) {
+            if (rect instanceof Gesture) {
+                ((Gesture)rect).setStart();
+            }
+
             rect.move(xChange, yChange);
-            if(rect instanceof Gesture){((Gesture)rect).snapY();}
+            if (rect instanceof Gesture) {
+                ((Gesture)rect).snapY();
+            }
             rect.updateNoteMoved();
         }
         selection.execute();

--- a/src/tunecomposer/NoteBar.java
+++ b/src/tunecomposer/NoteBar.java
@@ -100,7 +100,7 @@ public class NoteBar extends TuneRectangle {
                 composition.clearSelection();
                 getHighestParent().addToSelection();
             }
-            TuneComposer.history.addNewCommand(new SelectionCommand());
+            TuneComposer.history.addNewCommand(new SelectionCommand(composition));
             TuneComposer.menuBar.update();
             me.consume();
         }
@@ -155,12 +155,12 @@ public class NoteBar extends TuneRectangle {
         if (dragWidth) {
             composition.updateResized();
             composition.resetSelectionRight();
-            TuneComposer.history.addNewCommand(new ResizeCommand(composition.getSelectionTop() , me.getX()-dragStartX));
+            TuneComposer.history.addNewCommand(new ResizeCommand(composition, composition.getSelectionTop() , me.getX()-dragStartX));
         } else {
             composition.updateMoved();
             composition.snapSelectionY();
             composition.resetSelectionBounds();
-            TuneComposer.history.addNewCommand(new MoveCommand(composition.getSelectionTop(), me.getX()-dragStartX, me.getY()-dragStartY));
+            TuneComposer.history.addNewCommand(new MoveCommand(composition, composition.getSelectionTop(), me.getX()-dragStartX, me.getY()-dragStartY));
         }
         TuneComposer.menuBar.update();
         me.consume();

--- a/src/tunecomposer/NoteBar.java
+++ b/src/tunecomposer/NoteBar.java
@@ -17,15 +17,17 @@ public class NoteBar extends TuneRectangle {
 
 
     static final HashSet<NoteBar> ALLNOTEBARS = new HashSet<>();
-    final Note note;
+    public final Note note;
     private static boolean dragWidth;
+    private final Composition composition;
 
     /**
      * Create a new note bar.
      * @param note The note that this bar will display on screen.
      */
-    public NoteBar(Note note) {
+    public NoteBar(Note note, Composition composition) {
         this.note = note;
+        this.composition = composition;
 
         getStyleClass().add("note");
         setHeight(Constants.LINE_SPACING - Constants.LINE_THICKNESS);
@@ -36,7 +38,7 @@ public class NoteBar extends TuneRectangle {
         setOnMouseDragged((MouseEvent me) -> { onMouseDragged(me); });
         setOnMouseReleased((MouseEvent me) -> { onMouseReleased(me); });
 
-        TuneComposer.composition.add(this);
+        composition.add(this);
         ALLNOTEBARS.add(this);
         addToSelection();
     }
@@ -48,7 +50,7 @@ public class NoteBar extends TuneRectangle {
     public void delete(Pane compositionpane) {
         note.delete();
         ALLNOTEBARS.remove(this);
-        TuneComposer.composition.remove(this); //TODO probably should handle this elsewhere
+        composition.remove(this); //TODO probably should handle this elsewhere
     }
 
     /**
@@ -79,7 +81,7 @@ public class NoteBar extends TuneRectangle {
      */
     private boolean isSelected() {
         TuneRectangle root = getHighestParent();
-        return TuneComposer.composition.isSelectedTop(root);
+        return composition.isSelectedTop(root);
     }
 
     /**
@@ -90,12 +92,12 @@ public class NoteBar extends TuneRectangle {
         if (me.isStillSincePress()) {
             if (me.isControlDown()) {
                 if (isSelected()) {
-                    TuneComposer.composition.removeFromSelection(getHighestParent());
+                    composition.removeFromSelection(getHighestParent());
                 } else {
                     getHighestParent().addToSelection();
                 }
             } else {
-                TuneComposer.composition.clearSelection();
+                composition.clearSelection();
                 getHighestParent().addToSelection();
             }
             TuneComposer.history.addNewCommand(new SelectionCommand());
@@ -112,7 +114,7 @@ public class NoteBar extends TuneRectangle {
         dragWidth = (me.getX() >= rightEdge - 5);
         dragStartX = me.getX();
         dragStartY = me.getY();
-        TuneComposer.composition.setSelectionStart();
+        composition.setSelectionStart();
 
         // Maybe this NoteBar isn't selected yet
         if(getHighestParent() instanceof Gesture) {((Gesture) getHighestParent()).setStart();}
@@ -128,19 +130,19 @@ public class NoteBar extends TuneRectangle {
     private void onMouseDragged(MouseEvent me) {
         // If this notebar is not already selected, make it the only selection
         if (!isSelected()) {
-            TuneComposer.composition.clearSelection();
+            composition.clearSelection();
             getHighestParent().addToSelection();
         }
 
         if (dragWidth) {
             if(parentGesture == null) {
                 double dragDeltaWidth = me.getX() - dragStartX;
-                TuneComposer.composition.resizeSelected(dragDeltaWidth);
+                composition.resizeSelected(dragDeltaWidth);
             }
         } else {
             double dragDeltaX = me.getX() - dragStartX;
             double dragDeltaY = me.getY() - dragStartY;
-            TuneComposer.composition.moveSelected(dragDeltaX, dragDeltaY);
+            composition.moveSelected(dragDeltaX, dragDeltaY);
         }
         me.consume();
     }
@@ -151,14 +153,14 @@ public class NoteBar extends TuneRectangle {
      */
     private void onMouseReleased(MouseEvent me) {
         if (dragWidth) {
-            TuneComposer.composition.updateResized();
-            TuneComposer.composition.resetSelectionRight();
-            TuneComposer.history.addNewCommand(new ResizeCommand(TuneComposer.composition.getSelectionTop() , me.getX()-dragStartX));
+            composition.updateResized();
+            composition.resetSelectionRight();
+            TuneComposer.history.addNewCommand(new ResizeCommand(composition.getSelectionTop() , me.getX()-dragStartX));
         } else {
-            TuneComposer.composition.updateMoved();
-            TuneComposer.composition.snapSelectionY();
-            TuneComposer.composition.resetSelectionBounds();
-            TuneComposer.history.addNewCommand(new MoveCommand(TuneComposer.composition.getSelectionTop(), me.getX()-dragStartX, me.getY()-dragStartY));
+            composition.updateMoved();
+            composition.snapSelectionY();
+            composition.resetSelectionBounds();
+            TuneComposer.history.addNewCommand(new MoveCommand(composition.getSelectionTop(), me.getX()-dragStartX, me.getY()-dragStartY));
         }
         TuneComposer.menuBar.update();
         me.consume();
@@ -168,7 +170,7 @@ public class NoteBar extends TuneRectangle {
      */
     public void addToSelection() {
         if (parentGesture == null) {
-            TuneComposer.composition.addToSelection(this);
+            composition.addToSelection(this);
         }
         if(!getStyleClass().contains("selected")) { //this works, change it if we have time
             getStyleClass().add("selected");

--- a/src/tunecomposer/NoteBar.java
+++ b/src/tunecomposer/NoteBar.java
@@ -155,12 +155,12 @@ public class NoteBar extends TuneRectangle {
         if (dragWidth) {
             composition.updateResized();
             composition.resetSelectionRight();
-            TuneComposer.history.addNewCommand(new ResizeCommand(composition, composition.getSelectionTop() , me.getX()-dragStartX));
+            TuneComposer.history.addNewCommand(new ResizeCommand(composition, me.getX()-dragStartX));
         } else {
             composition.updateMoved();
             composition.snapSelectionY();
             composition.resetSelectionBounds();
-            TuneComposer.history.addNewCommand(new MoveCommand(composition, composition.getSelectionTop(), me.getX()-dragStartX, me.getY()-dragStartY));
+            TuneComposer.history.addNewCommand(new MoveCommand(composition, me.getX()-dragStartX, me.getY()-dragStartY));
         }
         TuneComposer.menuBar.update();
         me.consume();

--- a/src/tunecomposer/ResizeCommand.java
+++ b/src/tunecomposer/ResizeCommand.java
@@ -13,17 +13,20 @@ import java.util.Set;
  * @author vankoesd
  */
 public class ResizeCommand implements Command {
-        
+
+    private final Composition composition;
     private final Set<TuneRectangle> editedRects;
     private final double lengthChange;
     private final Command selection;
 
-    public ResizeCommand(Set<TuneRectangle> edits, double dragLength) {
+    public ResizeCommand(Composition composition, Set<TuneRectangle> edits,
+            double dragLength) {
+        this.composition = composition;
         editedRects = edits;
         lengthChange = dragLength;
         System.out.println(dragLength);
         System.out.println(edits);
-        selection = new SelectionCommand();
+        selection = new SelectionCommand(composition);
     }
     
     /**
@@ -36,7 +39,7 @@ public class ResizeCommand implements Command {
                 ((NoteBar) rect).resize(lengthChange);
             }
         }
-        TuneComposer.composition.updateResized();
+        composition.updateResized();
         selection.execute();
     }
 
@@ -50,7 +53,7 @@ public class ResizeCommand implements Command {
                 ((NoteBar) rect).resize(-lengthChange);
             }
         }
-        TuneComposer.composition.updateResized();
+        composition.updateResized();
         selection.unexecute();
     }
 }

--- a/src/tunecomposer/ResizeCommand.java
+++ b/src/tunecomposer/ResizeCommand.java
@@ -19,13 +19,10 @@ public class ResizeCommand implements Command {
     private final double lengthChange;
     private final Command selection;
 
-    public ResizeCommand(Composition composition, Set<TuneRectangle> edits,
-            double dragLength) {
+    public ResizeCommand(Composition composition, double dragLength) {
         this.composition = composition;
-        editedRects = edits;
+        editedRects = composition.getSelectionTop();
         lengthChange = dragLength;
-        System.out.println(dragLength);
-        System.out.println(edits);
         selection = new SelectionCommand(composition);
     }
     

--- a/src/tunecomposer/SelectionCommand.java
+++ b/src/tunecomposer/SelectionCommand.java
@@ -14,11 +14,13 @@ import java.util.Set;
  */
 public class SelectionCommand implements Command{
     
+    private final Composition composition;
     private final Set<TuneRectangle> changedRects;
 
-    public SelectionCommand() {
-        changedRects = new HashSet<>(TuneComposer.composition.getSelectionTracker());
-        TuneComposer.composition.clearSelectionTracker();
+    public SelectionCommand(Composition composition) {
+        this.composition = composition;
+        changedRects = new HashSet<>(composition.getSelectionTracker());
+        composition.clearSelectionTracker();
     }
     
     /**
@@ -42,8 +44,8 @@ public class SelectionCommand implements Command{
      */
     private void toggle(){
         for(TuneRectangle rect : changedRects){
-            if(TuneComposer.composition.isSelectedTop(rect)){
-                TuneComposer.composition.removeFromSelection(rect);
+            if(composition.isSelectedTop(rect)){
+                composition.removeFromSelection(rect);
             }
             else{
                 rect.addToSelection();

--- a/src/tunecomposer/TuneComposer.java
+++ b/src/tunecomposer/TuneComposer.java
@@ -61,7 +61,7 @@ public class TuneComposer extends Application {
     public TuneComposer() {
         player = new MidiPlayer(Constants.TICKS_PER_BEAT,
                                 Constants.BEATS_PER_MINUTE);
-        history = new CommandHistory();
+        history = new CommandHistory(composition);
     }
 
     /**
@@ -348,7 +348,7 @@ public class TuneComposer extends Application {
             if (!event.isControlDown()) {
                 composition.clearSelection();
             }
-            NoteBar forCommand = new NoteBar(note);
+            NoteBar forCommand = new NoteBar(note, composition);
             history.addNewCommand(new CreationCommand(forCommand));
         }
         menuBar.update();

--- a/src/tunecomposer/TuneComposer.java
+++ b/src/tunecomposer/TuneComposer.java
@@ -151,7 +151,12 @@ public class TuneComposer extends Application {
      * prepares the composition and the menubar
      */
     private void setupComposition() {
+        composition = new Composition(compositionpane);
+    }
+
+    private void setupMenuBar() {
         menuBar = new TuneMenuBar(
+                composition,
                 stopButton,
                 playButton,
                 selectNoneButton,
@@ -161,8 +166,6 @@ public class TuneComposer extends Application {
                 ungroupButton,
                 undoButton,
                 redoButton);
-
-        composition = new Composition(compositionpane);
     }
 
     /**
@@ -385,7 +388,7 @@ public class TuneComposer extends Application {
         setupSelectionRect();
         setupInstruments();
         setupComposition();
-        
+        setupMenuBar();
     }
 
     /**

--- a/src/tunecomposer/TuneComposer.java
+++ b/src/tunecomposer/TuneComposer.java
@@ -61,7 +61,6 @@ public class TuneComposer extends Application {
     public TuneComposer() {
         player = new MidiPlayer(Constants.TICKS_PER_BEAT,
                                 Constants.BEATS_PER_MINUTE);
-        history = new CommandHistory(composition);
     }
 
     /**
@@ -154,6 +153,10 @@ public class TuneComposer extends Application {
         composition = new Composition(compositionpane);
     }
 
+    private void setupCommandHistory() {
+        history = new CommandHistory(composition);
+    }
+
     private void setupMenuBar() {
         menuBar = new TuneMenuBar(
                 composition,
@@ -193,7 +196,7 @@ public class TuneComposer extends Application {
     @FXML
     protected void handleSelectAllAction(ActionEvent event) {
         composition.selectAll();
-        history.addNewCommand(new SelectionCommand());
+        history.addNewCommand(new SelectionCommand(composition));
         menuBar.update();
     }
 
@@ -204,7 +207,7 @@ public class TuneComposer extends Application {
     @FXML
     protected void handleSelectNoneAction(ActionEvent event) {
         composition.clearSelection();
-        history.addNewCommand(new SelectionCommand());
+        history.addNewCommand(new SelectionCommand(composition));
         menuBar.update();
     }
 
@@ -330,7 +333,7 @@ public class TuneComposer extends Application {
         NoteBar.selectArea(selectionRect);
         selectionRect.setVisible(false);
         if (!event.isStillSincePress()) {
-            history.addNewCommand(new SelectionCommand());
+            history.addNewCommand(new SelectionCommand(composition));
         }
         menuBar.update();
     }
@@ -352,7 +355,7 @@ public class TuneComposer extends Application {
                 composition.clearSelection();
             }
             NoteBar forCommand = new NoteBar(note, composition);
-            history.addNewCommand(new CreationCommand(forCommand));
+            history.addNewCommand(new CreationCommand(composition, forCommand));
         }
         menuBar.update();
         event.consume();
@@ -388,6 +391,7 @@ public class TuneComposer extends Application {
         setupSelectionRect();
         setupInstruments();
         setupComposition();
+        setupCommandHistory();
         setupMenuBar();
     }
 

--- a/src/tunecomposer/TuneMenuBar.java
+++ b/src/tunecomposer/TuneMenuBar.java
@@ -9,10 +9,11 @@ import javafx.scene.control.MenuItem;
 
 /**
  * handles the graying out of menu items
- * @author Ben, Ian, spencer
+ * @author Ben, Ian, Spencer
  */
 public class TuneMenuBar {
     
+    private Composition composition;
     private MenuItem stopButton;
     private MenuItem playButton;
     private MenuItem selectNoneButton;
@@ -24,6 +25,7 @@ public class TuneMenuBar {
     private MenuItem redoButton;
     
     public TuneMenuBar(
+            Composition composition,
             MenuItem stopButton,
             MenuItem playButton, 
             MenuItem selectNoneButton,
@@ -34,6 +36,7 @@ public class TuneMenuBar {
             MenuItem undoButton,
             MenuItem redoButton) {
 
+        this.composition        = composition;
         this.stopButton         = stopButton;
         this.playButton         = playButton;
         this.selectNoneButton   = selectNoneButton;
@@ -65,7 +68,7 @@ public class TuneMenuBar {
     /**
      * Checks all non stop button buttons and updates their disability.
      */
-    public void update(){
+    public void update() {
         updatePlay();
         updateSelect();
         updateDelete();
@@ -77,30 +80,30 @@ public class TuneMenuBar {
      * Updates the play button, for a change in number of notes.
      */
     private void updatePlay() {
-        playButton.setDisable(0 == TuneComposer.composition.size());
+        playButton.setDisable(0 == composition.size());
     }
     
     /**
      * Updates the selectall and selectnone buttons.
      */
     private void updateSelect(){
-        selectAllButton.setDisable(TuneComposer.composition.size() <= TuneComposer.composition.getSelectionSize());
-        selectNoneButton.setDisable(0 == TuneComposer.composition.getSelectionSize());
+        selectAllButton.setDisable(composition.size() <= composition.getSelectionSize());
+        selectNoneButton.setDisable(0 == composition.getSelectionSize());
     }
     
     /**
      * Updates the delete button.
      */
     private void updateDelete(){
-        deleteButton.setDisable(TuneComposer.composition.getSelectionSize() == 0);
+        deleteButton.setDisable(composition.getSelectionSize() == 0);
     }
     
     /**
      * Update group and ungroup buttons.
      */
     private void updateGroupUngroup(){
-        groupButton.setDisable(TuneComposer.composition.getSelectionSize() <= 1);
-        ungroupButton.setDisable(!TuneComposer.composition.isGestureSelected());
+        groupButton.setDisable(composition.getSelectionSize() <= 1);
+        ungroupButton.setDisable(!composition.isGestureSelected());
     }
     
     /**
@@ -130,5 +133,4 @@ public class TuneMenuBar {
     private void disable(MenuItem button) {
         button.setDisable(true);
     }
-}   
-   
+}


### PR DESCRIPTION
Tested and working. `TuneComposer.composition` is still global, but access to it has been made more explicit. Remaining global accesses are only in methods for which significant refactoring is needed, specifically in methods of `Gesture`.